### PR TITLE
build: upload sysroots to az instead of s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,13 @@
 version: 2.1
 
+orbs:
+  azure-cli: circleci/azure-cli@1.2.2
+
 commands:
   prepare:
     steps:
       - checkout
-      - run: sudo pip install s3cmd
-      - run: sudo apt install -y binutils-arm-linux-gnueabi binutils-arm-linux-gnueabihf binutils-mips64el-linux-gnuabi64 binutils-mipsel-linux-gnu
+      - run: sudo apt update && sudo apt install -y binutils-arm-linux-gnueabi binutils-arm-linux-gnueabihf binutils-mips64el-linux-gnuabi64 binutils-mipsel-linux-gnu
       - run:
           name: Fix the freetype stuff, idek
           command:  |
@@ -40,15 +42,17 @@ jobs:
           image: << parameters.image >>
   upload-images:
     docker:
-      - image: circleci/python:2.7-buster
+      - image: cimg/base:2022.04
     resource_class: large
     steps:
       - prepare
+      - azure-cli/install
+      - run: sudo apt install python2
       - attach_workspace:
           at: .
       - run:
           name: Upload Sysroots
-          command: SKIP_SYSROOT_BUILD=true ./build/linux/sysroot_scripts/build_and_upload.py
+          command: SKIP_SYSROOT_BUILD=true python2 ./build/linux/sysroot_scripts/build_and_upload.py
       - store_artifacts:
           path: build/linux/sysroot_scripts/sysroots.json
           destination: sysroots.json

--- a/build/linux/sysroot_scripts/build_and_upload.py
+++ b/build/linux/sysroot_scripts/build_and_upload.py
@@ -45,7 +45,7 @@ def build_and_upload(script_path, distro, release, arch, lock):
 
   if "SKIP_SYSROOT_BUILD" not in os.environ:
     run_script([script_path, 'BuildSysroot' + arch])
-  if "AWS_SECRET_ACCESS_KEY" in os.environ:
+  if "AZURE_STORAGE_SAS_TOKEN" in os.environ:
     run_script([script_path, 'UploadSysroot' + arch])
 
   tarball = '%s_%s_%s_sysroot.tar.xz' % (distro, release, arch.lower())

--- a/build/linux/sysroot_scripts/sysroot-creator.sh
+++ b/build/linux/sysroot_scripts/sysroot-creator.sh
@@ -723,9 +723,9 @@ BuildSysrootAll() {
 
 UploadSysroot() {
   local sha=$(sha1sum "${TARBALL}" | awk '{print $1;}')
+  local tarball_name="$(basename "${TARBALL}")"
   set -x
-  s3cmd put --acl-public "${TARBALL}" \
-      "s3://${ELECTRON_S3_BUCKET}/toolchain/$sha/"
+  az storage blob upload -f "${TARBALL}" -c linux-sysroots -n $sha/"${tarball_name}"
   set +x
 }
 


### PR DESCRIPTION
As in title, moves our sysroots to the new dev-cdn.electronjs.org endpoint