### PR TITLE
feat: add "URL" field to sysroots.json

### DIFF
--- a/build/linux/sysroot_scripts/build_and_upload.py
+++ b/build/linux/sysroot_scripts/build_and_upload.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 
 ARCHES = ("amd64", "i386", "armhf", "arm64", "armel", "mipsel", "mips64el")
+DEFAULT_URL_PREFIX = "https://dev-cdn.electronjs.org/linux-sysroots"
 
 
 def sha1sumfile(filename):
@@ -52,6 +53,7 @@ def build_and_upload(script_path, distro, release, key, arch, lock):
       "Sha1Sum": sha1sum,
       "SysrootDir": sysroot_dir,
       "Tarball": tarball,
+      "URL": DEFAULT_URL_PREFIX,
   }
   with lock:
     fname = os.path.join(script_dir, "sysroots.json")


### PR DESCRIPTION
See https://chromium-review.googlesource.com/c/chromium/src/+/4702051.

With this change we will be able to specify the location of sysroot images without patching Chromium.