### PR TITLE
fix: building with GTK4

### DIFF
--- a/build/linux/sysroot_scripts/sysroot-creator.sh
+++ b/build/linux/sysroot_scripts/sysroot-creator.sh
@@ -799,6 +799,14 @@ HacksAndPatches() {
     "${INSTALL_ROOT}/lib/${TRIPLE}/libm.so.6"
   "${SCRIPT_DIR}/reversion_glibc.py" \
     "${INSTALL_ROOT}/lib/${TRIPLE}/libcrypt.so.1"
+
+  # GTK4 is provided by bookworm (12), but pango is provided by bullseye
+  # (11). Fix the GTK4 pkgconfig file to relax the pango version
+  # requirement.
+  local gtk4_pc="${INSTALL_ROOT}/usr/lib/pkgconfig/gtk4.pc"
+
+  sed -i -E 's/pango [>=0-9. ]*/pango/' "$gtk4_pc"
+  sed -i -E 's/pangocairo [>=0-9. ]*/pangocairo/' "$gtk4_pc"
 }
 
 InstallIntoSysroot() {


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/chromium/src/+/5240858.

Fixes the following:

```
Package dependency requirement 'pango >= 1.50.0' could not be satisfied.
Package 'pango' has version '1.46.2', required version is '>= 1.50.0'
Package dependency requirement 'pangocairo >= 1.50.0' could not be satisfied.
Package 'pangocairo' has version '1.46.2', required version is '>= 1.50.0'
```

Electron itself won't yet compile with gtk4, but this unblocks fixing compiler errors.