### PR TITLE
fix: reintroduce support for Ubuntu 18.04 and Debian 10

### DIFF
--- a/build/linux/sysroot_scripts/reversion_glibc.py
+++ b/build/linux/sysroot_scripts/reversion_glibc.py
@@ -1,0 +1,124 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+"""Rewrite incompatible default symbols in glibc.
+"""
+
+import re
+import subprocess
+
+# This constant comes from the oldest glibc version in
+# //chrome/installer/linux/debian/dist_package_versions.json and
+# //chrome/installer/linux/rpm/dist_package_provides.json
+MAX_ALLOWED_GLIBC_VERSION = [2, 26]
+
+VERSION_PATTERN = re.compile("GLIBC_([0-9\.]+)")
+SECTION_PATTERN = re.compile(r"^ *\[ *[0-9]+\] +(\S+) +\S+ + ([0-9a-f]+) .*$")
+
+# Some otherwise disallowed symbols are referenced in the linux-chromeos build.
+# To continue supporting it, allow these symbols to remain enabled.
+SYMBOL_ALLOWLIST = {
+    "fts64_close",
+    "fts64_open",
+    "fts64_read",
+    "memfd_create",
+}
+
+
+def reversion_glibc(bin_file: str) -> None:
+    # The two dictionaries below map from symbol name to
+    # (symbol version, symbol index).
+    #
+    # The default version for a given symbol (which may be unsupported).
+    default_version = {}
+    # The max supported symbol version for a given symbol.
+    supported_version = {}
+
+    # Populate |default_version| and |supported_version| with data from readelf.
+    stdout = subprocess.check_output(
+        ["readelf", "--dyn-syms", "--wide", bin_file])
+    for line in stdout.decode("utf-8").split("\n"):
+        cols = re.split("\s+", line)
+        # Skip the preamble.
+        if len(cols) < 9:
+            continue
+
+        index = cols[1].rstrip(":")
+        # Skip the header.
+        if not index.isdigit():
+            continue
+
+        index = int(index)
+        name = cols[8].split("@")
+        # Ignore unversioned symbols.
+        if len(name) < 2:
+            continue
+
+        base_name = name[0]
+        version = name[-1]
+        # The default version will have '@@' in the name.
+        is_default = len(name) > 2
+
+        if version.startswith("XCRYPT_"):
+            # Prefer GLIBC_* versioned symbols over XCRYPT_* ones.
+            # Set the version to something > MAX_ALLOWED_GLIBC_VERSION
+            # so this symbol will not be picked.
+            version = [10**10]
+        else:
+            match = re.match(VERSION_PATTERN, version)
+            # Ignore symbols versioned with GLIBC_PRIVATE.
+            if not match:
+                continue
+            version = [int(part) for part in match.group(1).split(".")]
+
+        if version < MAX_ALLOWED_GLIBC_VERSION:
+            old_supported_version = supported_version.get(
+                base_name, ([-1], -1))
+            supported_version[base_name] = max((version, index),
+                                               old_supported_version)
+        if is_default:
+            default_version[base_name] = (version, index)
+
+    # Get the offset into the binary of the .gnu.version section from readelf.
+    stdout = subprocess.check_output(
+        ["readelf", "--sections", "--wide", bin_file])
+    for line in stdout.decode("utf-8").split("\n"):
+        if match := SECTION_PATTERN.match(line):
+            section_name, address = match.groups()
+            if section_name == ".gnu.version":
+                gnu_version_addr = int(address, base=16)
+                break
+    else:
+        raise Exception("No .gnu.version section found")
+
+    # Rewrite the binary.
+    bin_data = bytearray(open(bin_file, "rb").read())
+    for name, (version, index) in default_version.items():
+        # No need to rewrite the default if it's already an allowed version.
+        if version <= MAX_ALLOWED_GLIBC_VERSION:
+            continue
+
+        if name in SYMBOL_ALLOWLIST:
+            continue
+        elif name in supported_version:
+            _, supported_index = supported_version[name]
+        else:
+            supported_index = -1
+
+        # The .gnu.version section is divided into 16-bit chunks that give the
+        # symbol versions.  The 16th bit is a flag that's false for the default
+        # version.  The data is stored in little-endian so we need to add 1 to
+        # get the address of the byte we want to flip.
+        #
+        # Disable the unsupported symbol.
+        old_default = gnu_version_addr + 2 * index + 1
+        assert (bin_data[old_default] & 0x80) == 0
+        bin_data[old_default] ^= 0x80
+
+        # If we found a supported version, enable that as default.
+        if supported_index != -1:
+            new_default = gnu_version_addr + 2 * supported_index + 1
+            assert (bin_data[new_default] & 0x80) == 0x80
+            bin_data[new_default] ^= 0x80
+
+    open(bin_file, "wb").write(bin_data)

--- a/build/linux/sysroot_scripts/sysroot_creator.py
+++ b/build/linux/sysroot_scripts/sysroot_creator.py
@@ -17,6 +17,7 @@ import tempfile
 import time
 
 import requests
+import reversion_glibc
 
 DISTRO = "debian"
 RELEASE = "bullseye"
@@ -798,6 +799,34 @@ def hacks_and_patches(install_root: str, script_dir: str, arch: str) -> None:
                      "symbols"),
     )
 
+    # __GLIBC_MINOR__ is used as a feature test macro. Replace it with the
+    # earliest supported version of glibc (2.26).
+    features_h = os.path.join(install_root, "usr", "include", "features.h")
+    replace_in_file(features_h, r"(#define\s+__GLIBC_MINOR__)", r"\1 26 //")
+
+    # fcntl64() was introduced in glibc 2.28. Make sure to use fcntl() instead.
+    fcntl_h = os.path.join(install_root, "usr", "include", "fcntl.h")
+    replace_in_file(
+        fcntl_h,
+        r"#ifndef __USE_FILE_OFFSET64(\nextern int fcntl)",
+        r"#if 1\1",
+    )
+
+    # Do not use pthread_cond_clockwait as it was introduced in glibc 2.30.
+    cppconfig_h = os.path.join(
+        install_root,
+        "usr",
+        "include",
+        TRIPLES[arch],
+        "c++",
+        "10",
+        "bits",
+        "c++config.h",
+    )
+    replace_in_file(cppconfig_h,
+                    r"(#define\s+_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT)",
+                    r"// \1")
+
     # Include limits.h in stdlib.h to fix an ODR issue.
     stdlib_h = os.path.join(install_root, "usr", "include", "stdlib.h")
     replace_in_file(stdlib_h, r"(#include <stddef.h>)",
@@ -812,6 +841,11 @@ def hacks_and_patches(install_root: str, script_dir: str, arch: str) -> None:
         for file in os.listdir(triple_pkgconfig_dir):
             shutil.move(os.path.join(triple_pkgconfig_dir, file),
                         pkgconfig_dir)
+
+    # Avoid requiring unsupported glibc versions.
+    for lib in ["libc.so.6", "libm.so.6", "libcrypt.so.1"]:
+        lib_path = os.path.join(install_root, "lib", TRIPLES[arch], lib)
+        reversion_glibc.reversion_glibc(lib_path)
 
     # GTK4 is provided by bookworm (12), but pango is provided by bullseye
     # (11).  Fix the GTK4 pkgconfig file to relax the pango version


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/chromium/src/+/6192197

Chromium removed it and then reintroduced it for similar reasons we are now - RHEL 8 is supported for several more years.

Closes https://github.com/electron/electron/issues/45884.