### PR TITLE
build: only build sysroots when needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: "Build and Upload Sysroots"
 
 on:
   push:
+    paths:
+      - build/linux/sysroot_scripts
+      - .github/workflows/build.yml
 
 permissions:
   contents: write


### PR DESCRIPTION
As in title. Don't build new sysroots when we haven't changed any relevant files.