### PR TITLE
ci: fix push path filter to match files inside `sysroot_scripts` directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: "Build and Upload Sysroots"
 on:
   push:
     paths:
-      - build/linux/sysroot_scripts
+      - build/linux/sysroot_scripts/**
       - .github/workflows/build.yml
 
 permissions:


### PR DESCRIPTION
The paths filter `sysroot_scripts` only matches the directory entry itself, not files within it. This means pushes that modify files like `sysroot_creator.py` or `build_and_upload.py` inside the directory would not trigger the workflow.

Changed to `build/linux/sysroot_scripts/**` which uses a glob pattern to match any file at any depth within the directory.