### PR TITLE
chore: remove AZURE_STORAGE_SAS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ To upload sysroots to the Azure storage container after they've been generated, 
 ./build/linux/sysroot_scripts/build_and_upload.py --build
 ```
 
-Ensure you have a valid `AZURE_STORAGE_SAS_TOKEN` as well as `AZURE_STORAGE_ACCOUNT` in your environment, or upload will fail.
+Ensure you are logged into Azure as well as setting `AZURE_STORAGE_ACCOUNT` in your environment, or upload will fail.

--- a/build/linux/sysroot_scripts/build_and_upload.py
+++ b/build/linux/sysroot_scripts/build_and_upload.py
@@ -28,8 +28,6 @@ def build_and_upload(key, arch, lock, action):
         sysroot_creator.build_sysroot(arch)
 
     if action & Action.UPLOAD:
-        if "AZURE_STORAGE_SAS_TOKEN" not in os.environ:
-            raise RuntimeError("AZURE_STORAGE_SAS_TOKEN is required to upload sysroots")
         sysroot_creator.upload_sysroot(arch)
 
     tarball = "%s_%s_%s_sysroot.tar.xz" % (


### PR DESCRIPTION
- Followup to #71.   AZURE_STORAGE_SAS_TOKEN is no longer needed, so we should not try to validate that value existing.