### PR TITLE
chore: fixup az upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,6 @@ jobs:
         run: |
           json_url="https://raw.githubusercontent.com/electron/electron/main/script/sysroots.json"
           curl --output build/linux/sysroot_scripts/sysroots.json $json_url -H "Accept: application/json"
-          az extension add --name storage-preview
       - name: Upload Sysroots to Azure
         run: ./build/linux/sysroot_scripts/build_and_upload.py --upload
       - name: Upload Sysroot JSON Artifact

--- a/build/linux/sysroot_scripts/sysroot_creator.py
+++ b/build/linux/sysroot_scripts/sysroot_creator.py
@@ -816,6 +816,7 @@ def upload_sysroot(arch: str) -> str:
     sha = sha256sumfile(tarball_path)
     command = [
         "az", "storage", "blob", "upload",
+        "--auth-mode", "login",
         "-f", tarball_path,
         "-c", "linux-sysroots",
         "-n", sha,


### PR DESCRIPTION
- Follow up to #71 and #72.  Using an OIDC login requires that we pass the `--auth-mode login` argument when running `az storage blob upload`.